### PR TITLE
FreeBSD: ImageMagick6-nox11 => ImageMagick7-nox11

### DIFF
--- a/redmine/osfamilymap.yaml
+++ b/redmine/osfamilymap.yaml
@@ -16,7 +16,7 @@ FreeBSD:
     - subversion
     - git
     - rubygem-bundler
-    - ImageMagick6-nox11
+    - ImageMagick7-nox11
     # subversion needs this to verify TLS connections / x509 certs
     - ca_root_nss
   apache_snippet_dir: /usr/local/etc/apache24/extra


### PR DESCRIPTION
Updated a dependency.

Tested on FreeBSD 11.2.